### PR TITLE
fix: resolve all MoonBit compiler warnings

### DIFF
--- a/src/element.mbt
+++ b/src/element.mbt
@@ -48,7 +48,7 @@ pub fn Element::make(self : Element, name : String) -> Element {
 
 ///|
 pub fn Element::new(
-  run : (@immut/hashmap.T[String, String]) -> String
+  run : (@immut/hashmap.T[String, String]) -> String,
 ) -> Element {
   { run, }
 }
@@ -80,10 +80,10 @@ fn build_attr(key : String, val : String) -> String {
 }
 
 ///|
-fn fold_map_with_key[M : Add, K, V](
+fn[M : Add, K, V] fold_map_with_key(
   init~ : M,
   f : (K, V) -> M,
-  m : @immut/hashmap.T[K, V]
+  m : @immut/hashmap.T[K, V],
 ) -> M {
   m.iter().fold(init~, fn { acc, (k, v) => acc + f(k, v) })
 }
@@ -195,7 +195,7 @@ pub fn feColorMatrix(attrs : Array[Attribute], child? : Element) -> Element {
 /// feComponentTransfer element
 pub fn feComponentTransfer(
   attrs : Array[Attribute],
-  child? : Element
+  child? : Element,
 ) -> Element {
   term("feComponentTransfer", attrs, child?)
 }
@@ -306,7 +306,7 @@ pub fn fePointLight(attrs : Array[Attribute], child? : Element) -> Element {
 /// feSpecularLighting element
 pub fn feSpecularLighting(
   attrs : Array[Attribute],
-  child? : Element
+  child? : Element,
 ) -> Element {
   term("feSpecularLighting", attrs, child?)
 }

--- a/src/element.mbt
+++ b/src/element.mbt
@@ -85,18 +85,23 @@ fn[M : Add, K, V] fold_map_with_key(
   f : (K, V) -> M,
   m : @immut/hashmap.T[K, V],
 ) -> M {
-  m.iter().fold(init~, fn { acc, (k, v) => acc + f(k, v) })
+  m
+  .iter()
+  .fold(init~, fn(acc, entry) {
+    let (k, v) = entry
+    acc + f(k, v)
+  })
 }
 
 ///|
 fn build_map(arr : Array[Attribute]) -> @immut/hashmap.T[String, String] {
   let map = @immut/hashmap.new()
   let l = arr.length()
-  loop l, map {
-    0, acc => acc
-    i, acc => {
+  loop (l, map) {
+    (0, acc) => acc
+    (i, acc) => {
       let val = arr[i - 1]
-      continue i - 1, acc.add(val.attr, val.value)
+      continue (i - 1, acc.add(val.attr, val.value))
     }
   }
 }
@@ -111,7 +116,7 @@ pub fn term(name : String, arr : Array[Attribute], child? : Element) -> Element 
 
 ///|
 pub fn Element::str(str : String) -> Element {
-  Element::new(fn { _ => str })
+  Element::new(fn(_) { str })
 }
 
 ///|

--- a/src/path.mbt
+++ b/src/path.mbt
@@ -3,138 +3,138 @@ pub(open) trait RealFloat: @lg.Num + Show {}
 
 ///|
 /// moveto (absolute)
-pub fn ma[N : RealFloat](x : N, y : N) -> String {
+pub fn[N : RealFloat] ma(x : N, y : N) -> String {
   "M \{x},\{y} "
 }
 
 ///|
 /// moveto (relative)
-pub fn mr[N : RealFloat](dx : N, dy : N) -> String {
+pub fn[N : RealFloat] mr(dx : N, dy : N) -> String {
   "m \{dx},\{dy} "
 }
 
 ///|
 /// lineto (absolute)
-pub fn la[N : RealFloat](x : N, y : N) -> String {
+pub fn[N : RealFloat] la(x : N, y : N) -> String {
   "L \{x},\{y} "
 }
 
 ///|
 /// lineto (relative)
-pub fn lr[N : RealFloat](dx : N, dy : N) -> String {
+pub fn[N : RealFloat] lr(dx : N, dy : N) -> String {
   "l \{dx},\{dy} "
 }
 
 ///|
 /// horizontal lineto (absolute)
-pub fn ha[N : RealFloat](x : N) -> String {
+pub fn[N : RealFloat] ha(x : N) -> String {
   "H \{x} "
 }
 
 ///|
 /// horizontal lineto (relative)
-pub fn hr[N : RealFloat](dx : N) -> String {
+pub fn[N : RealFloat] hr(dx : N) -> String {
   "h \{dx} "
 }
 
 ///|
 /// vertical lineto (absolute)
-pub fn va[N : RealFloat](y : N) -> String {
+pub fn[N : RealFloat] va(y : N) -> String {
   "V \{y} "
 }
 
 ///|
 /// vertical lineto (relative)
-pub fn vr[N : RealFloat](dy : N) -> String {
+pub fn[N : RealFloat] vr(dy : N) -> String {
   "v \{dy} "
 }
 
 ///|
 /// Cubic Bezier curve (absolute)
-pub fn ca[N : RealFloat](
+pub fn[N : RealFloat] ca(
   c1x : N,
   c1y : N,
   c2x : N,
   c2y : N,
   x : N,
-  y : N
+  y : N,
 ) -> String {
   "C \{c1x},\{c1y} \{c2x},\{c2y} \{x},\{y}"
 }
 
 ///|
 /// Cubic Bezier curve (relative)
-pub fn cr[N : RealFloat](
+pub fn[N : RealFloat] cr(
   dc1x : N,
   dc1y : N,
   dc2x : N,
   dc2y : N,
   dx : N,
-  dy : N
+  dy : N,
 ) -> String {
   "c \{dc1x},\{dc1y} \{dc2x},\{dc2y} \{dx},\{dy}"
 }
 
 ///|
 /// Smooth Cubic Bezier curve (absolute)
-pub fn sa[N : RealFloat](c2x : N, c2y : N, x : N, y : N) -> String {
+pub fn[N : RealFloat] sa(c2x : N, c2y : N, x : N, y : N) -> String {
   "S \{c2x},\{c2y} \{x},\{y} "
 }
 
 ///|
 /// Smooth Cubic Bezier curve (relative)
-pub fn sr[N : RealFloat](dc2x : N, dc2y : N, dx : N, dy : N) -> String {
+pub fn[N : RealFloat] sr(dc2x : N, dc2y : N, dx : N, dy : N) -> String {
   "s \{dc2x},\{dc2y} \{dx},\{dy} "
 }
 
 ///|
 /// Quadratic Bezier curve (absolute)
-pub fn qa[N : RealFloat](cx : N, cy : N, x : N, y : N) -> String {
+pub fn[N : RealFloat] qa(cx : N, cy : N, x : N, y : N) -> String {
   "Q \{cx},\{cy} \{x},\{y} "
 }
 
 ///|
 /// Quadratic Bezier curve (relative)
-pub fn qr[N : RealFloat](dcx : N, dcy : N, dx : N, dy : N) -> String {
+pub fn[N : RealFloat] qr(dcx : N, dcy : N, dx : N, dy : N) -> String {
   "q \{dcx},\{dcy} \{dx},\{dy} "
 }
 
 ///|
 /// Smooth Quadratic Bezier curve (absolute)
-pub fn ta[N : RealFloat](x : N, y : N) -> String {
+pub fn[N : RealFloat] ta(x : N, y : N) -> String {
   "T \{x},\{y} "
 }
 
 ///|
 /// Smooth Quadratic Bezier curve (relative)
-pub fn tr[N : RealFloat](x : N, y : N) -> String {
+pub fn[N : RealFloat] tr(x : N, y : N) -> String {
   "t \{x},\{y} "
 }
 
 ///|
 /// Arc (absolute)
-pub fn aa[N : RealFloat](
+pub fn[N : RealFloat] aa(
   rx : N,
   ry : N,
   xrot : N,
   large_flag : N,
   sweep_flag : N,
   x : N,
-  y : N
+  y : N,
 ) -> String {
   "A \{rx},\{ry} \{xrot} \{large_flag} \{sweep_flag} \{x} \{y} "
 }
 
 ///|
 /// Arc (relative)
-pub fn ar[N : RealFloat](
+pub fn[N : RealFloat] ar(
   rx : N,
   ry : N,
   xrot : N,
   large_flag : N,
   sweep_flag : N,
   x : N,
-  y : N
+  y : N,
 ) -> String {
   "a \{rx},\{ry} \{xrot} \{large_flag} \{sweep_flag} \{x} \{y} "
 }
@@ -148,49 +148,49 @@ pub fn z() -> String {
 ///|
 /// SVG Transform components
 /// Specifies a translation by x and y
-pub fn translate[N : RealFloat](x : N, y : N) -> String {
+pub fn[N : RealFloat] translate(x : N, y : N) -> String {
   "translate(\{x} \{y})"
 }
 
 ///|
 /// Specifies a scale operation by x and y
-pub fn scale[N : RealFloat](x : N, y : N) -> String {
+pub fn[N : RealFloat] scale(x : N, y : N) -> String {
   "scale(\{x} \{y})"
 }
 
 ///|
 /// Specifies a rotation by rotate-angle degrees
-pub fn rotate[N : RealFloat](angle : N) -> String {
+pub fn[N : RealFloat] rotate(angle : N) -> String {
   "rotate(\{angle})"
 }
 
 ///|
 /// Specifies a rotation by rotate-angle degrees about the given point rx,ry
-pub fn rotate_around[N : RealFloat](angle : N, rx : N, ry : N) -> String {
+pub fn[N : RealFloat] rotate_around(angle : N, rx : N, ry : N) -> String {
   "rotate(\{angle},\{rx},\{ry})"
 }
 
 ///|
 /// Skew transformation along x-axis
-pub fn skew_x[N : RealFloat](angle : N) -> String {
+pub fn[N : RealFloat] skew_x(angle : N) -> String {
   "skewX(\{angle})"
 }
 
 ///|
 /// Skew transformation along y-axis
-pub fn skew_y[N : RealFloat](angle : N) -> String {
+pub fn[N : RealFloat] skew_y(angle : N) -> String {
   "skewY(\{angle})"
 }
 
 ///|
 /// Specifies a transform in the form of a transformation matrix
-pub fn matrix[N : RealFloat](
+pub fn[N : RealFloat] matrix(
   a : N,
   b : N,
   c : N,
   d : N,
   e : N,
-  f : N
+  f : N,
 ) -> String {
   "matrix(\{a},\{b},\{c},\{d},\{e},\{f})"
 }

--- a/src/render_test.mbt
+++ b/src/render_test.mbt
@@ -2,11 +2,11 @@
 test {
   let r = a([@svg.XlinkActuate["11"], @svg.X["123"]]) +
     g([@svg.Y["123"], @svg.Z["114514"]])
-  inspect!(
+  inspect(
     r,
-    content=
+    content=(
       #|<a x="123" xlink:actuate="11"/><g z="114514" y="123"/>
-    ,
+    ),
   )
 }
 
@@ -59,6 +59,7 @@ fn logo_hsk() -> Element {
     ma(331, 156)],
   ])
 }
+
 ///|
 
 ///|
@@ -74,11 +75,11 @@ test {
   }
 
   let logo_svg = logo_hsk() |> svg_it()
-  inspect!(
+  inspect(
     logo_svg,
-    content=
+    content=(
       #|<!DOCTYPE svg><svg height="100%" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 340" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="100%"><path fill="#352950" d="M 0,340 L 113,170 L 0,0 L 85,0 L 198,170 L 85,340 L 0,340 Z M 0,340 "/><path fill="#4A3A74" d="M 113,340 L 226,170 L 113,0 L 198,0 L 425,340 L 340,340 L 269,234 L 198,340 L 113,340 Z M 113,340 "/><path fill="#7C3679" d="M 387,241 L 350,184 L 482,184 L 482,241 L 387,241 Z M 387,241 "/><path fill="#7C3679" d="M 331,156 L 293,99 L 482,99 L 482,156 L 331,156 Z M 331,156 "/></svg>
-    ,
+    ),
   )
 }
 
@@ -93,7 +94,7 @@ test {
     ])
   }
 
-  let svg = rect([@svg.Width["100%"], @svg.Height["100%"], @svg.Fill["red"]]) +
+  let svg = (rect([@svg.Width["100%"], @svg.Height["100%"], @svg.Fill["red"]]) +
     circle([@svg.Cx["150"], @svg.Cy["100"], @svg.R["80"], @svg.Fill["green"]]) +
     text(
       [
@@ -104,12 +105,12 @@ test {
         @svg.Fill["white"],
       ],
       child=Element::str("SVG"),
-    )
+    ))
     |> svg_it2()
-  inspect!(
+  inspect(
     svg,
-    content=
+    content=(
       #|<!DOCTYPE svg><svg height="200" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="300"><rect fill="red" height="100%" width="100%"/><circle fill="green" cy="100" r="80" cx="150"/><text fill="white" text-anchor="middle" x="150" y="125" font-size="60">SVG</text></svg>
-    ,
+    ),
   )
 }

--- a/src/render_test.mbt
+++ b/src/render_test.mbt
@@ -66,7 +66,9 @@ fn logo_hsk() -> Element {
 test {
   fn svg_it(e : Element) -> Element {
     doc_type() +
-    with_attr(e.svg11(), [
+    e
+    .svg11()
+    .with_attr([
       @svg.Version["1.1"],
       @svg.Width["100%"],
       @svg.Height["100%"],
@@ -87,7 +89,7 @@ test {
 test {
   fn svg_it2(contents) {
     doc_type() +
-    svg11(contents).with_attr([
+    Element::svg11(contents).with_attr([
       @svg.Version["1.1"],
       @svg.Width["300"],
       @svg.Height["200"],

--- a/src/svg.mbti
+++ b/src/svg.mbti
@@ -1,3 +1,4 @@
+// Generated using `moon info`, DON'T EDIT IT
 package "CAIMEOX/svg"
 
 import(
@@ -8,7 +9,7 @@ import(
 // Values
 fn a(Array[Attribute], child? : Element) -> Element
 
-fn aa[N : RealFloat](N, N, N, N, N, N, N) -> String
+fn[N : RealFloat] aa(N, N, N, N, N, N, N) -> String
 
 fn animate(Array[Attribute], child? : Element) -> Element
 
@@ -16,9 +17,9 @@ fn animateMotion(Array[Attribute], child? : Element) -> Element
 
 fn animateTransform(Array[Attribute], child? : Element) -> Element
 
-fn ar[N : RealFloat](N, N, N, N, N, N, N) -> String
+fn[N : RealFloat] ar(N, N, N, N, N, N, N) -> String
 
-fn ca[N : RealFloat](N, N, N, N, N, N) -> String
+fn[N : RealFloat] ca(N, N, N, N, N, N) -> String
 
 fn circle(Array[Attribute], child? : Element) -> Element
 
@@ -26,7 +27,7 @@ fn clipPath(Array[Attribute], child? : Element) -> Element
 
 fn colorProfile(Array[Attribute], child? : Element) -> Element
 
-fn cr[N : RealFloat](N, N, N, N, N, N) -> String
+fn[N : RealFloat] cr(N, N, N, N, N, N) -> String
 
 fn cursor(Array[Attribute], child? : Element) -> Element
 
@@ -108,29 +109,29 @@ fn glyph(Array[Attribute], child? : Element) -> Element
 
 fn glyphRef(Array[Attribute]) -> Element
 
-fn ha[N : RealFloat](N) -> String
+fn[N : RealFloat] ha(N) -> String
 
 fn hkern(Array[Attribute]) -> Element
 
-fn hr[N : RealFloat](N) -> String
+fn[N : RealFloat] hr(N) -> String
 
 fn image(Array[Attribute], child? : Element) -> Element
 
-fn la[N : RealFloat](N, N) -> String
+fn[N : RealFloat] la(N, N) -> String
 
 fn line(Array[Attribute], child? : Element) -> Element
 
 fn linearGradient(Array[Attribute], child? : Element) -> Element
 
-fn lr[N : RealFloat](N, N) -> String
+fn[N : RealFloat] lr(N, N) -> String
 
-fn ma[N : RealFloat](N, N) -> String
+fn[N : RealFloat] ma(N, N) -> String
 
 fn marker(Array[Attribute], child? : Element) -> Element
 
 fn mask(Array[Attribute], child? : Element) -> Element
 
-fn matrix[N : RealFloat](N, N, N, N, N, N) -> String
+fn[N : RealFloat] matrix(N, N, N, N, N, N) -> String
 
 fn metadata(Array[Attribute], child? : Element) -> Element
 
@@ -138,11 +139,9 @@ fn missingGlyph(Array[Attribute], child? : Element) -> Element
 
 fn mpath(Array[Attribute], child? : Element) -> Element
 
-fn mr[N : RealFloat](N, N) -> String
+fn[N : RealFloat] mr(N, N) -> String
 
 fn new(String, String) -> Attribute
-
-fn op_get(Tag, String) -> Attribute
 
 fn path(Array[Attribute], child? : Element) -> Element
 
@@ -152,31 +151,31 @@ fn polygon(Array[Attribute], child? : Element) -> Element
 
 fn polyline(Array[Attribute], child? : Element) -> Element
 
-fn qa[N : RealFloat](N, N, N, N) -> String
+fn[N : RealFloat] qa(N, N, N, N) -> String
 
-fn qr[N : RealFloat](N, N, N, N) -> String
+fn[N : RealFloat] qr(N, N, N, N) -> String
 
 fn radialGradient(Array[Attribute], child? : Element) -> Element
 
 fn rect(Array[Attribute], child? : Element) -> Element
 
-fn rotate[N : RealFloat](N) -> String
+fn[N : RealFloat] rotate(N) -> String
 
-fn rotate_around[N : RealFloat](N, N, N) -> String
+fn[N : RealFloat] rotate_around(N, N, N) -> String
 
-fn sa[N : RealFloat](N, N, N, N) -> String
+fn[N : RealFloat] sa(N, N, N, N) -> String
 
-fn scale[N : RealFloat](N, N) -> String
+fn[N : RealFloat] scale(N, N) -> String
 
 fn script(Array[Attribute], child? : Element) -> Element
 
 fn set(Array[Attribute], child? : Element) -> Element
 
-fn skew_x[N : RealFloat](N) -> String
+fn[N : RealFloat] skew_x(N) -> String
 
-fn skew_y[N : RealFloat](N) -> String
+fn[N : RealFloat] skew_y(N) -> String
 
-fn sr[N : RealFloat](N, N, N, N) -> String
+fn[N : RealFloat] sr(N, N, N, N) -> String
 
 fn stop(Array[Attribute], child? : Element) -> Element
 
@@ -184,13 +183,11 @@ fn style(Array[Attribute], child? : Element) -> Element
 
 fn svg(Array[Attribute], child? : Element) -> Element
 
-fn svg11(Element) -> Element
-
 fn switch(Array[Attribute], child? : Element) -> Element
 
 fn symbol(Array[Attribute], child? : Element) -> Element
 
-fn ta[N : RealFloat](N, N) -> String
+fn[N : RealFloat] ta(N, N) -> String
 
 fn term(String, Array[Attribute], child? : Element) -> Element
 
@@ -200,9 +197,9 @@ fn textPath(Array[Attribute], child? : Element) -> Element
 
 fn title(Array[Attribute], child? : Element) -> Element
 
-fn tr[N : RealFloat](N, N) -> String
+fn[N : RealFloat] tr(N, N) -> String
 
-fn translate[N : RealFloat](N, N) -> String
+fn[N : RealFloat] translate(N, N) -> String
 
 fn tref(Array[Attribute], child? : Element) -> Element
 
@@ -210,17 +207,17 @@ fn tspan(Array[Attribute], child? : Element) -> Element
 
 fn use_(Array[Attribute], child? : Element) -> Element
 
-fn va[N : RealFloat](N) -> String
+fn[N : RealFloat] va(N) -> String
 
 fn view(Array[Attribute], child? : Element) -> Element
 
 fn vkern(Array[Attribute]) -> Element
 
-fn vr[N : RealFloat](N) -> String
-
-fn with_attr(Element, Array[Attribute]) -> Element
+fn[N : RealFloat] vr(N) -> String
 
 fn z() -> String
+
+// Errors
 
 // Types and methods
 type Attribute
@@ -229,15 +226,13 @@ impl Hash for Attribute
 impl Show for Attribute
 
 type Element
-impl Element {
-  doc_type(String) -> Self
-  make(Self, String) -> Self
-  make_empty(String) -> Self
-  new((@hashmap.T[String, String]) -> String) -> Self
-  str(String) -> Self
-  svg11(Self) -> Self
-  with_attr(Self, Array[Attribute]) -> Self
-}
+fn Element::doc_type(String) -> Self
+fn Element::make(Self, String) -> Self
+fn Element::make_empty(String) -> Self
+fn Element::new((@hashmap.T[String, String]) -> String) -> Self
+fn Element::str(String) -> Self
+fn Element::svg11(Self) -> Self
+fn Element::with_attr(Self, Array[Attribute]) -> Self
 impl Add for Element
 impl Show for Element
 
@@ -507,9 +502,7 @@ pub(all) enum Tag {
   Z
   ZoomAndPan
 }
-impl Tag {
-  op_get(Self, String) -> Attribute
-}
+fn Tag::op_get(Self, String) -> Attribute
 impl Eq for Tag
 impl Hash for Tag
 impl Show for Tag


### PR DESCRIPTION
> [!NOTE]
> This PR was made by an LLM agent.

This commit addresses all deprecated syntax warnings by modernizing the codebase:

- Convert deprecated anonymous matrix function syntax `fn { .. }` to modern function syntax
- Update deprecated loop syntax `loop a, b { ... }` to `loop (a, b) { ... }`
- Modernize method call syntax from `f(..)` to `x.f(..)` or `T::f(..)` where appropriate

The following specific changes were made:

1. **src/element.mbt**:
   - Fixed `fold_map_with_key` function to use modern lambda syntax
   - Updated `build_map` function to use parentheses in loop arguments
   - Modernized anonymous function in `Element::str`

2. **src/render_test.mbt**:
   - Updated method call chains to use modern method syntax
   - Fixed static method calls to use explicit type qualification

All changes maintain the existing functionality while eliminating compiler warnings. The codebase now compiles cleanly without any deprecation warnings.